### PR TITLE
Diminuir height das article-cards

### DIFF
--- a/src/main/webapp/app/backoffice/revision/revision-card/revision-card.component.html
+++ b/src/main/webapp/app/backoffice/revision/revision-card/revision-card.component.html
@@ -2,16 +2,16 @@
   <div class="cardHeader ellipsis-overflowed">
     {{ revision?.title }}
   </div>
-  <div class="article-card-body">
+  <div class="revision-card-body">
     <div>
       <span class="review-status">
         {{ status }}
       </span>
-      <span class="articleDetailsColor">
+      <span class="revisionDetailsColor">
         <i class="fal fa-hashtag"></i>
         <span>{{ article?.id }}</span>
       </span>
-      <span class="articleDetailsColor">
+      <span class="revisionDetailsColor">
         <i class="fal fa-calendar-alt"></i>
         <span>{{ revision?.reviewDate | date }}</span>
       </span>

--- a/src/main/webapp/app/backoffice/revision/revision-card/revision-card.scss
+++ b/src/main/webapp/app/backoffice/revision/revision-card/revision-card.scss
@@ -20,7 +20,7 @@
   margin-bottom: 20px;
 }
 
-.articleDetailsColor {
+.revisionDetailsColor {
   color: #151344;
 }
 
@@ -59,7 +59,7 @@ round-card {
   }
 }
 
-.article-card-body {
+.revision-card-body {
   padding: 0;
   height: 300px;
 

--- a/src/main/webapp/app/shared/article-card/article-card.component.html
+++ b/src/main/webapp/app/shared/article-card/article-card.component.html
@@ -1,5 +1,5 @@
 <round-card paddingTop="0" paddingBottom="0" paddingLeft="35px" paddingRight="35px" *ngFor="let article of articles">
-    <div class="cardHeader ellipsis-overflowed">
+    <div class="cardHeader">
         {{ article?.articleTitle }}
     </div>
     <div class="article-card-body">

--- a/src/main/webapp/app/shared/article-card/article-card.component.html
+++ b/src/main/webapp/app/shared/article-card/article-card.component.html
@@ -26,9 +26,8 @@
             </icam-badge>
         </div>
         <div>
-            <div>
-                {{ article?.articleAbstract }}
-            </div>
+            <div *ngIf="article?.articleAbstract as abstract; else noAbstract">{{abstract}}</div>
+            <ng-template #noAbstract>Não foi possível extrair o abstract - veja o original.</ng-template>
             <div>
                 <span>
                     <i class="fal fa-newspaper"></i>

--- a/src/main/webapp/app/shared/article-card/article-card.scss
+++ b/src/main/webapp/app/shared/article-card/article-card.scss
@@ -7,11 +7,11 @@
 .cardHeader {
   text-align: left;
   font: 28px/38px Roboto;
-  padding: 35px 0;
+  padding: 25px 0;
   letter-spacing: 0px;
   color: #151344;
   opacity: 1;
-  height: 100px;
+  min-height: 90px;
   border-bottom: 1px solid #f2f2f4;
 }
 
@@ -25,12 +25,12 @@
 }
 
 round-card {
-  min-height: 500px;
+  min-height: 300px;
   margin-top: 50px;
 }
 
 #rowH {
-  padding: 35px 0;
+  padding: 24px 0;
   border-top: 1px solid #f2f2f4;
 
   & > span {
@@ -47,6 +47,7 @@ round-card {
 
   @media only screen and (max-width: 670px) {
     text-align: center;
+    padding: 0 0 10px 0;
 
     span {
       display: block;
@@ -61,10 +62,10 @@ round-card {
 
 .article-card-body {
   padding: 0;
-  height: 300px;
+  height: 155px;
 
   @media only screen and (max-width: 670px) {
-    height: 500px;
+    height: 300px;
   }
 
   & > div:first-child {
@@ -72,7 +73,11 @@ round-card {
     border-right: 1px solid #f2f2f4;
     width: 300px;
     float: left;
-    padding-top: 35px;
+    padding-top: 25px;
+
+    @media only screen and (max-width: 670px) {
+      padding-top: 10px;
+    }
 
     & > * {
       display: block;
@@ -108,12 +113,13 @@ round-card {
 
   & > div:last-child {
     width: auto;
-    padding: 35px 0 35px 35px;
+    padding: 25px 0 35px 35px;
     overflow: hidden;
     height: 100%;
 
     @media only screen and (max-width: 670px) {
-      height: 300px;
+      padding: 20px 0 35px 35px;
+      height: 170px;
     }
 
     div {
@@ -176,6 +182,10 @@ round-card {
   @media only screen and (max-width: 670px) {
     float: none;
   }
+}
+
+.cardFooter {
+  height: 100%;
 }
 
 button {


### PR DESCRIPTION
Closes #36 

### Objetivo principal
Reduzir o tamanho das article cards para melhorar a user experience (mais artigos por ecrã, scroll mais rápido)

### Outras alterações
Changed css class names of revision-card from "article" to "revision"
Minor improvements and rework na responsividade
Agora se não existir abstract na DB, aparece texto no sítio a dizer que "não foi possível extrair"